### PR TITLE
Add APK support to Ahab

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ To use `ahab`, assuming you have a built version of it:
 
 * `dpkg-query --show --showformat='${Package} ${Version}\n' | ./ahab chase`
 * `yum list installed | ./ahab chase --os fedora`
+* `apk info -vv | sort | ./ahab chase --os alpine`
 
-`ahab` currently works for images that use `apt` or `yum` for package management.
+`ahab` currently works for images that use `apt`, `apk` or `yum` for package management.
 
 ## Why is this useful?
 

--- a/main.go
+++ b/main.go
@@ -90,7 +90,6 @@ func tryParseStdInList(list []string, operating *string) {
 }
 
 func tryAuditPackages(purls []string, count int) {
-	fmt.Println(purls)
 	coordinates, err := ossindex.AuditPackages(purls)
 	if err != nil {
 		fmt.Print(err)

--- a/main.go
+++ b/main.go
@@ -73,12 +73,16 @@ func tryExtractAndAudit(pkgs packages.IPackage, operating string) {
 func tryParseStdInList(list []string, operating *string) {
 	var thing string
 	thing = *operating
-	if thing == "debian" {
+	switch thing {
+	case "debian":
 		var aptResult packages.Apt
-		//aptResult.ProjectList = parse.ParseAptListFromStdIn(list)
 		aptResult.ProjectList = parse.ParseDpkgList(list)
 		tryExtractAndAudit(aptResult, thing)
-	} else {
+	case "alpine":
+		var apkResult packages.Apk
+		apkResult.ProjectList = parse.ParseApkShow(list)
+		tryExtractAndAudit(apkResult, thing)
+	default:
 		var yumResult packages.Yum
 		yumResult.ProjectList = parse.ParseYumListFromStdIn(list)
 		tryExtractAndAudit(yumResult, thing)
@@ -86,7 +90,7 @@ func tryParseStdInList(list []string, operating *string) {
 }
 
 func tryAuditPackages(purls []string, count int) {
-	//fmt.Print(purls)
+	fmt.Println(purls)
 	coordinates, err := ossindex.AuditPackages(purls)
 	if err != nil {
 		fmt.Print(err)

--- a/packages/apk.go
+++ b/packages/apk.go
@@ -1,0 +1,32 @@
+// Copyright 2019 Sonatype Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package packages
+
+import (
+	"fmt"
+
+	types "github.com/sonatype-nexus-community/nancy/types"
+)
+
+type Apk struct {
+	ProjectList types.ProjectList
+}
+
+func (a Apk) ExtractPurlsFromProjectList(operating string) (purls []string) {
+	for _, s := range a.ProjectList.Projects {
+		var purl = fmt.Sprintf("pkg:alpine/%s@%s", s.Name, s.Version)
+		purls = append(purls, purl)
+	}
+	return
+}

--- a/parse/apk.go
+++ b/parse/apk.go
@@ -22,8 +22,7 @@ import (
 
 func ParseApkShow(packages []string) (projectList types.ProjectList) {
 	for _, pkg := range packages {
-		if strings.Contains(pkg, "WARNING") {
-		} else {
+		if !strings.Contains(pkg, "WARNING") {
 			projectList.Projects = append(projectList.Projects, doApkShowParse(pkg))
 		}
 	}

--- a/parse/apk.go
+++ b/parse/apk.go
@@ -14,6 +14,7 @@
 package parse
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -32,31 +33,16 @@ func ParseApkShow(packages []string) (projectList types.ProjectList) {
 func doApkShowParse(pkg string) (parsedProject types.Projects) {
 	pkg = strings.TrimSpace(pkg)
 	splitPackage := strings.Split(pkg, " ")
-	parsedProject.Name = doApkShowParseName(splitPackage[0])
-	parsedProject.Version = doApkShowParseVersion(splitPackage[0])
-	return
-}
-
-func doApkShowParseName(pkg string) (name string) {
-	re, err := regexp.Compile("([a-zA-Z][a-zA-Z0-9]+-)+")
+	re, err := regexp.Compile(`^((.*)-([^a-zA-Z].*)-.*)`)
 	if err != nil {
 		panic(err)
 	}
-	results := re.FindStringSubmatch(pkg)
-	if results != nil {
-		name = strings.TrimSuffix(results[0], "-")
-	}
-	return
-}
-
-func doApkShowParseVersion(pkg string) (version string) {
-	re, err := regexp.Compile("([0-9]+)(\\.[0-9]+)(\\.[0-9]+)?(-[r][0-9]+)")
-	if err != nil {
-		panic(err)
-	}
-	results := re.FindStringSubmatch(pkg)
-	if results != nil {
-		version = results[0]
+	newSlice := re.FindStringSubmatch(splitPackage[0])
+	if newSlice != nil {
+		parsedProject.Name = newSlice[2]
+		parsedProject.Version = newSlice[3]
+	} else {
+		fmt.Printf("Failure parsing name, version for package")
 	}
 	return
 }

--- a/parse/apk.go
+++ b/parse/apk.go
@@ -1,0 +1,64 @@
+// Copyright 2019 Sonatype Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package parse
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/sonatype-nexus-community/nancy/types"
+)
+
+func ParseApkShow(packages []string) (projectList types.ProjectList) {
+	for _, pkg := range packages {
+		if strings.Contains(pkg, "WARNING") {
+		} else {
+			projectList.Projects = append(projectList.Projects, doApkShowParse(pkg))
+		}
+	}
+	return
+}
+
+func doApkShowParse(pkg string) (parsedProject types.Projects) {
+	pkg = strings.TrimSpace(pkg)
+	splitPackage := strings.Split(pkg, " ")
+	parsedProject.Name = doApkShowParseName(splitPackage[0])
+	parsedProject.Version = doApkShowParseVersion(splitPackage[0])
+	return
+}
+
+func doApkShowParseName(pkg string) (name string) {
+	re, err := regexp.Compile("([a-zA-Z][a-zA-Z0-9]+-)+")
+	if err != nil {
+		fmt.Println(err)
+	}
+	results := re.FindStringSubmatch(pkg)
+	if results != nil {
+		name = strings.TrimSuffix(results[0], "-")
+	}
+	return
+}
+
+func doApkShowParseVersion(pkg string) (version string) {
+	re, err := regexp.Compile("([0-9]+)(\\.[0-9]+)(\\.[0-9]+)?(-[r][0-9]+)")
+	if err != nil {
+		fmt.Println(err)
+	}
+	results := re.FindStringSubmatch(pkg)
+	if results != nil {
+		version = results[0]
+	}
+	return
+}

--- a/parse/apk.go
+++ b/parse/apk.go
@@ -14,7 +14,6 @@
 package parse
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 
@@ -42,7 +41,7 @@ func doApkShowParse(pkg string) (parsedProject types.Projects) {
 func doApkShowParseName(pkg string) (name string) {
 	re, err := regexp.Compile("([a-zA-Z][a-zA-Z0-9]+-)+")
 	if err != nil {
-		fmt.Println(err)
+		panic(err)
 	}
 	results := re.FindStringSubmatch(pkg)
 	if results != nil {
@@ -54,7 +53,7 @@ func doApkShowParseName(pkg string) (name string) {
 func doApkShowParseVersion(pkg string) (version string) {
 	re, err := regexp.Compile("([0-9]+)(\\.[0-9]+)(\\.[0-9]+)?(-[r][0-9]+)")
 	if err != nil {
-		fmt.Println(err)
+		panic(err)
 	}
 	results := re.FindStringSubmatch(pkg)
 	if results != nil {

--- a/parse/apk_test.go
+++ b/parse/apk_test.go
@@ -50,12 +50,12 @@ func TestParseApkShowList(t *testing.T) {
 		t.Errorf("Didn't work, expected %d projects but got %d", 14, len(result.Projects))
 	}
 
-	// adduser 3.116ubuntu1
-	assert.Equal(t, types.Projects{"alpine-baselayout", "3.1.2-r0"}, result.Projects[0])
+	// alpine-baselayout-3.1.2-r0
+	assert.Equal(t, types.Projects{"alpine-baselayout", "3.1.2"}, result.Projects[0])
 
-	// apt 1.6.12
-	assert.Equal(t, types.Projects{"alpine-keys", "2.1-r2"}, result.Projects[1])
+	// alpine-keys-2.1-r2
+	assert.Equal(t, types.Projects{"alpine-keys", "2.1"}, result.Projects[1])
 
-	// ca-certificates 20180409
-	assert.Equal(t, types.Projects{"apk-tools", "2.10.4-r2"}, result.Projects[2])
+	// apk-tools-2.10.4-r2
+	assert.Equal(t, types.Projects{"apk-tools", "2.10.4"}, result.Projects[2])
 }

--- a/parse/apk_test.go
+++ b/parse/apk_test.go
@@ -1,0 +1,56 @@
+package parse_test
+
+import (
+	"strings"
+	"testing"
+
+	. "github.com/sonatype-nexus-community/ahab/parse"
+	"github.com/sonatype-nexus-community/nancy/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseApkShow(t *testing.T) {
+	var list []string
+	list = append(list, "alpine-baselayout-3.1.2-r0 - Alpine base dir structure and init scripts")
+	list = append(list, "alpine-keys-2.1-r2 - Public keys for Alpine Linux packages")
+	list = append(list, "apk-tools-2.10.4-r2 - Alpine Package Keeper - package manager for alpine")
+	result := ParseApkShow(list)
+
+	if len(result.Projects) != 3 {
+		t.Errorf("Didn't work")
+	}
+}
+
+// generate CLI package list via:
+// # apk info -vv | sort
+var apkShowList = `WARNING: Ignoring APKINDEX.00740ba1.tar.gz: No such file or directory
+WARNING: Ignoring APKINDEX.d8b2a6f4.tar.gz: No such file or directory
+alpine-baselayout-3.1.2-r0 - Alpine base dir structure and init scripts
+alpine-keys-2.1-r2 - Public keys for Alpine Linux packages
+apk-tools-2.10.4-r2 - Alpine Package Keeper - package manager for alpine
+busybox-1.30.1-r2 - Size optimized toolbox of many common UNIX utilities
+ca-certificates-cacert-20190108-r0 - Mozilla bundled certificates
+libc-utils-0.7.1-r0 - Meta package to pull in correct libc
+libcrypto1.1-1.1.1c-r0 - Crypto library from openssl
+libssl1.1-1.1.1c-r0 - SSL shared libraries
+libtls-standalone-2.9.1-r0 - libtls extricated from libressl sources
+musl-1.1.22-r3 - the musl c library (libc) implementation
+musl-utils-1.1.22-r3 - the musl c library (libc) implementation
+scanelf-1.2.3-r0 - Scan ELF binaries for stuff
+ssl_client-1.30.1-r2 - EXternal ssl_client for busybox wget
+zlib-1.2.11-r1 - A compression/decompression Library`
+
+var apkShowArray = strings.Split(apkShowList, "\n")
+
+func TestParseApkShowList(t *testing.T) {
+	result := ParseApkShow(apkShowArray)
+
+	// adduser 3.116ubuntu1
+	assert.Equal(t, types.Projects{"alpine-baselayout", "3.1.2-r0"}, result.Projects[0])
+
+	// apt 1.6.12
+	assert.Equal(t, types.Projects{"alpine-keys", "2.1-r2"}, result.Projects[1])
+
+	// ca-certificates 20180409
+	assert.Equal(t, types.Projects{"apk-tools", "2.10.4-r2"}, result.Projects[2])
+}

--- a/parse/apk_test.go
+++ b/parse/apk_test.go
@@ -1,3 +1,16 @@
+// Copyright 2019 Sonatype Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package parse_test
 
 import (

--- a/parse/apk_test.go
+++ b/parse/apk_test.go
@@ -22,18 +22,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParseApkShow(t *testing.T) {
-	var list []string
-	list = append(list, "alpine-baselayout-3.1.2-r0 - Alpine base dir structure and init scripts")
-	list = append(list, "alpine-keys-2.1-r2 - Public keys for Alpine Linux packages")
-	list = append(list, "apk-tools-2.10.4-r2 - Alpine Package Keeper - package manager for alpine")
-	result := ParseApkShow(list)
-
-	if len(result.Projects) != 3 {
-		t.Errorf("Didn't work")
-	}
-}
-
 // generate CLI package list via:
 // # apk info -vv | sort
 var apkShowList = `WARNING: Ignoring APKINDEX.00740ba1.tar.gz: No such file or directory
@@ -57,6 +45,10 @@ var apkShowArray = strings.Split(apkShowList, "\n")
 
 func TestParseApkShowList(t *testing.T) {
 	result := ParseApkShow(apkShowArray)
+
+	if len(result.Projects) != 14 {
+		t.Errorf("Didn't work, expected %d projects but got %d", 14, len(result.Projects))
+	}
 
 	// adduser 3.116ubuntu1
 	assert.Equal(t, types.Projects{"alpine-baselayout", "3.1.2-r0"}, result.Projects[0])

--- a/parse/apk_test.go
+++ b/parse/apk_test.go
@@ -58,4 +58,7 @@ func TestParseApkShowList(t *testing.T) {
 
 	// apk-tools-2.10.4-r2
 	assert.Equal(t, types.Projects{"apk-tools", "2.10.4"}, result.Projects[2])
+
+	// ca-certificates-cacert-20190108-r0
+	assert.Equal(t, types.Projects{"ca-certificates-cacert", "20190108"}, result.Projects[4])
 }

--- a/testapk.txt
+++ b/testapk.txt
@@ -1,0 +1,16 @@
+WARNING: Ignoring APKINDEX.00740ba1.tar.gz: No such file or directory
+WARNING: Ignoring APKINDEX.d8b2a6f4.tar.gz: No such file or directory
+alpine-baselayout-3.1.2-r0 - Alpine base dir structure and init scripts
+alpine-keys-2.1-r2 - Public keys for Alpine Linux packages
+apk-tools-2.10.4-r2 - Alpine Package Keeper - package manager for alpine
+busybox-1.30.1-r2 - Size optimized toolbox of many common UNIX utilities
+ca-certificates-cacert-20190108-r0 - Mozilla bundled certificates
+libc-utils-0.7.1-r0 - Meta package to pull in correct libc
+libcrypto1.1-1.1.1c-r0 - Crypto library from openssl
+libssl1.1-1.1.1c-r0 - SSL shared libraries
+libtls-standalone-2.9.1-r0 - libtls extricated from libressl sources
+musl-1.1.22-r3 - the musl c library (libc) implementation
+musl-utils-1.1.22-r3 - the musl c library (libc) implementation
+scanelf-1.2.3-r0 - Scan ELF binaries for stuff
+ssl_client-1.30.1-r2 - EXternal ssl_client for busybox wget
+zlib-1.2.11-r1 - A compression/decompression Library


### PR DESCRIPTION
@ken-duck has added Alpine linux to OSS Index (soon anyways), so we can add apk support to `ahab`

This pull request makes the following changes:
* New APK files that do all the fun processing
* Regex stolen from `nexus-repository-apk` that parses version and name from an apk filename
* New test, and new `testapk.txt` to test this

This can be tested like so:

`cat testapk.txt | ./ahab chase --os alpine` or by running `apk info -vv | sort |./ahab chase --os alpine` if you run it in Alpine Linux

cc @bhamail / @DarthHater / @zendern
