### PR TITLE
Handle newline in ParseDpkgList

### DIFF
--- a/cmd/chase.go
+++ b/cmd/chase.go
@@ -190,19 +190,40 @@ func parseStdInList(list []string, operating *string) (packages.IPackage, error)
 	thing := *operating
 	switch thing {
 	case "debian":
-		logLady.Trace("Chasing Debian")
+		logLady.WithFields(logrus.Fields{
+			"list": list,
+		}).Trace("Chasing Debian")
+
 		var aptResult packages.Apt
 		aptResult.ProjectList = parse.ParseDpkgList(list)
+
+		logLady.WithFields(logrus.Fields{
+			"project_list": aptResult.ProjectList,
+		}).Trace("Obtained apt project list")
 		return aptResult, nil
 	case "alpine":
-		logLady.Trace("Chasing Alpine")
+		logLady.WithFields(logrus.Fields{
+			"list": list,
+		}).Trace("Chasing Alpine")
+
 		var apkResult packages.Apk
 		apkResult.ProjectList = parse.ParseApkShow(list)
+
+		logLady.WithFields(logrus.Fields{
+			"project_list": apkResult.ProjectList,
+		}).Trace("Obtained apk project list")
 		return apkResult, nil
 	default:
-		logLady.Trace("Chasing Yum")
+		logLady.WithFields(logrus.Fields{
+			"list": list,
+		}).Trace("Chasing Yum")
+
 		var yumResult packages.Yum
 		yumResult.ProjectList = parse.ParseYumListFromStdIn(list)
+
+		logLady.WithFields(logrus.Fields{
+			"project_list": yumResult.ProjectList,
+		}).Trace("Obtained yum project list")
 		return yumResult, nil
 	}
 }

--- a/parse/apt.go
+++ b/parse/apt.go
@@ -86,7 +86,10 @@ func doParseAptVersionIntoPurl(name string, version string) (newVersion string) 
 
 func ParseDpkgList(packages []string) (projectList ProjectList) {
 	for _, pkg := range packages {
-		projectList.Projects = append(projectList.Projects, doDpkgParse(pkg))
+		pkg = strings.TrimSpace(pkg)
+		if pkg != "" {
+			projectList.Projects = append(projectList.Projects, doDpkgParse(pkg))
+		}
 	}
 	return
 }

--- a/parse/apt_test.go
+++ b/parse/apt_test.go
@@ -261,7 +261,9 @@ vim-runtime 2:8.0.1453-1ubuntu1.1
 xdg-user-dirs 0.17-1ubuntu1
 xxd 2:8.0.1453-1ubuntu1.1
 xz-utils 5.2.2-1.3
-zlib1g 1:1.2.11.dfsg-0ubuntu2`
+zlib1g 1:1.2.11.dfsg-0ubuntu2
+
+`
 
 var dpkgListArray = strings.Split(dpkgList, "\n")
 

--- a/testapt.txt
+++ b/testapt.txt
@@ -1,11 +1,96 @@
-Listing... Done                                                                                                                                        
-wget/now 1.19.1-3build1 amd64 [installed,local]                                                                                                         
-adduser/now 3.116ubuntu1 all [installed,local]                                                                                                         
-apparmor/now 2.12-4ubuntu5.1 amd64 [installed,local]                                                                                                   
-apt/now 1.6.10 amd64 [installed,local]                                                                                                                 
-apt-utils/now 1.6.10 amd64 [installed,local]                                                                                                           
-base-files/now 10.1ubuntu2.4 amd64 [installed,local]                                                                                                   
-base-passwd/now 3.5.44 amd64 [installed,local]                                                                                                         
-bash/now 4.4.18-2ubuntu1 amd64 [installed,local]                                                                                                       
-bsdutils/now 1:2.31.1-0.4ubuntu3.3 amd64 [installed,local]                                                                                             
-btrfs-progs/now 4.15.1-1build1 amd64 [installed,local]                                                                                                 
+adduser 3.118ubuntu2
+apt 2.0.2ubuntu0.1
+base-files 11ubuntu5
+base-passwd 3.5.47
+bash 5.0-6ubuntu1
+bsdutils 1:2.34-0.1ubuntu9
+bzip2 1.0.8-2
+ca-certificates 20190110ubuntu1.1
+coreutils 8.30-3ubuntu2
+dash 0.5.10.2-6
+debconf 1.5.73
+debianutils 4.9.1
+diffutils 1:3.7-3
+dpkg 1.19.7ubuntu3
+e2fsprogs 1.45.5-2ubuntu1
+fdisk 2.34-0.1ubuntu9
+findutils 4.7.0-1ubuntu1
+gcc-10-base 10-20200411-0ubuntu1
+gpgv 2.2.19-3ubuntu2
+grep 3.4-1
+gzip 1.10-0ubuntu4
+hostname 3.23
+init-system-helpers 1.57
+libacl1 2.2.53-6
+libapt-pkg6.0 2.0.2ubuntu0.1
+libattr1 1:2.4.48-5
+libaudit-common 1:2.8.5-2ubuntu6
+libaudit1 1:2.8.5-2ubuntu6
+libblkid1 2.34-0.1ubuntu9
+libbz2-1.0 1.0.8-2
+libc-bin 2.31-0ubuntu9
+libc6 2.31-0ubuntu9
+libcap-ng0 0.7.9-2.1build1
+libcom-err2 1.45.5-2ubuntu1
+libcrypt1 1:4.4.10-10ubuntu4
+libdb5.3 5.3.28+dfsg1-0.6ubuntu2
+libdebconfclient0 0.251ubuntu1
+libext2fs2 1.45.5-2ubuntu1
+libfdisk1 2.34-0.1ubuntu9
+libffi7 3.3-4
+libgcc-s1 10-20200411-0ubuntu1
+libgcrypt20 1.8.5-5ubuntu1
+libgmp10 2:6.2.0+dfsg-4
+libgnutls30 3.6.13-2ubuntu1.2
+libgpg-error0 1.37-1
+libhogweed5 3.5.1+really3.5.1-2
+libidn2-0 2.2.0-2
+liblz4-1 1.9.2-2
+liblzma5 5.2.4-1
+libmount1 2.34-0.1ubuntu9
+libncurses6 6.2-0ubuntu2
+libncursesw6 6.2-0ubuntu2
+libnettle7 3.5.1+really3.5.1-2
+libp11-kit0 0.23.20-1build1
+libpam-modules 1.3.1-5ubuntu4
+libpam-modules-bin 1.3.1-5ubuntu4
+libpam-runtime 1.3.1-5ubuntu4
+libpam0g 1.3.1-5ubuntu4
+libpcre2-8-0 10.34-7
+libpcre3 2:8.39-12build1
+libprocps8 2:3.3.16-1ubuntu2
+libseccomp2 2.4.3-1ubuntu3.20.04.2
+libselinux1 3.0-1build2
+libsemanage-common 3.0-1build2
+libsemanage1 3.0-1build2
+libsepol1 3.0-1
+libsmartcols1 2.34-0.1ubuntu9
+libss2 1.45.5-2ubuntu1
+libssl1.1 1.1.1f-1ubuntu2
+libstdc++6 10-20200411-0ubuntu1
+libsystemd0 245.4-4ubuntu3.1
+libtasn1-6 4.16.0-2
+libtinfo6 6.2-0ubuntu2
+libudev1 245.4-4ubuntu3.1
+libunistring2 0.9.10-2
+libuuid1 2.34-0.1ubuntu9
+libzstd1 1.4.4+dfsg-3
+login 1:4.8.1-1ubuntu5.20.04
+logsave 1.45.5-2ubuntu1
+lsb-base 11.1.0ubuntu2
+mawk 1.3.4.20200120-2
+mount 2.34-0.1ubuntu9
+ncurses-base 6.2-0ubuntu2
+ncurses-bin 6.2-0ubuntu2
+openssl 1.1.1f-1ubuntu2
+passwd 1:4.8.1-1ubuntu5.20.04
+perl-base 5.30.0-9build1
+procps 2:3.3.16-1ubuntu2
+sed 4.7-1
+sensible-utils 0.0.12+nmu1
+sysvinit-utils 2.96-2.1ubuntu1
+tar 1.30+dfsg-7
+ubuntu-keyring 2020.02.11.2
+util-linux 2.34-0.1ubuntu9
+zlib1g 1:1.2.11.dfsg-2ubuntu1
+                                                                                        


### PR DESCRIPTION
I wanted to improve the testapt.txt file so that it had a full list based on `ubuntu:latest`, and when I went to do it, I added a newline, and it blew up! This adds some logic to skip empty lines, improves the `testapt.txt` to be more reflective of a real OS scenario, and adds a couple more trace log statements for debugging

This pull request makes the following changes:
* Adds test case with newline in `apt_test.go`
* Adds logic in `apt.go` to skip empty lines
* Adds log statements in `chase.go` so that we see what's getting sent around at a trace level

cc @bhamail / @DarthHater
