### PR TITLE
Show correct vuln count

### DIFF
--- a/audit/audit.go
+++ b/audit/audit.go
@@ -211,6 +211,14 @@ func formatPackage(sb *strings.Builder, noColor bool, idx int, packageCount int,
 func formatVulnerability(sb *strings.Builder, noColor bool, idx int, packageCount int, coordinate types.Coordinate) (err error) {
 	au := aurora.NewAurora(!noColor)
 
+	var numVulns int
+
+	for _, v := range coordinate.Vulnerabilities {
+		if !v.Excluded {
+			numVulns++
+		}
+	}
+
 	_, err = sb.WriteString(fmt.Sprintf(
 		"[%d/%d]\t%s\n%s \n",
 		idx,


### PR DESCRIPTION
If a vuln is excluded, we should reflect that in the "X known vulnerabilities found in" line

This pull request makes the following changes:
* Adds quick lil ditty to `formatVulnerability` in `audit.go` to show the correct number

It relates to the following issue #s: 
* Fixes #25

cc @bhamail / @DarthHater
