### PR TITLE
Detector fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 ahab
+ahab.exe
 vendor
 .DS_Store
 .vscode

--- a/packages/detector.go
+++ b/packages/detector.go
@@ -66,18 +66,12 @@ func determineIfPackageManagerInstalled(packageManager string, logger *logrus.Lo
 		if exitError, ok := err.(*exec.ExitError); ok {
 			waitStatus = exitError.Sys().(syscall.WaitStatus)
 			logger.Infof("Output 1: %s\n", []byte(fmt.Sprintf("%d", waitStatus.ExitStatus())))
-			if waitStatus.ExitStatus() == 0 {
-				return true
-			}
-			return false
+			return waitStatus.ExitStatus() == 0
 		}
 		return false
 	}
 	waitStatus = cmd.ProcessState.Sys().(syscall.WaitStatus)
 	logger.Info(string(output))
 	logger.Infof("Output 2: %s\n", []byte(fmt.Sprintf("%d", waitStatus.ExitStatus())))
-	if waitStatus.ExitStatus() == 0 {
-		return true
-	}
-	return false
+	return waitStatus.ExitStatus() == 0
 }

--- a/packages/detector.go
+++ b/packages/detector.go
@@ -66,23 +66,18 @@ func determineIfPackageManagerInstalled(packageManager string, logger *logrus.Lo
 		if exitError, ok := err.(*exec.ExitError); ok {
 			waitStatus = exitError.Sys().(syscall.WaitStatus)
 			logger.Infof("Output 1: %s\n", []byte(fmt.Sprintf("%d", waitStatus.ExitStatus())))
-			if waitStatus == 0 {
+			if waitStatus.ExitStatus() == 0 {
 				return true
-			}else{
-				return false
 			}
-		}else{
 			return false
 		}
-	} else {
-		// Success
-		waitStatus = cmd.ProcessState.Sys().(syscall.WaitStatus)
-		logger.Info(string(output))
-		logger.Infof("Output 2: %s\n", []byte(fmt.Sprintf("%d", waitStatus.ExitStatus())))
-		if waitStatus == 0 {
-			return true
-		}else{
-			return false
-		}
+		return false
 	}
+	waitStatus = cmd.ProcessState.Sys().(syscall.WaitStatus)
+	logger.Info(string(output))
+	logger.Infof("Output 2: %s\n", []byte(fmt.Sprintf("%d", waitStatus.ExitStatus())))
+	if waitStatus.ExitStatus() == 0 {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
Some tweaks to get this building on Windows (386, apparently)

This pull request makes the following changes:
* Switches from a `waitStatus == 0` to check to `waitStatus.ExitStatus() == 0`
* Minor dropping of `else` statements since they all contain `returns`

You can verify a build with `GOOS=windows GOARCH=386 go build`

Fixes issue seen in Release: https://app.circleci.com/pipelines/github/sonatype-nexus-community/ahab/34/workflows/49836bae-5481-479b-bff8-e3737bcc4022/jobs/39

cc @bhamail / @DarthHater / @zendern 
