### PR TITLE
remove darwin binary. fixes #36

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,7 +27,6 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
-      - darwin
       - windows
     goarch:
       - amd64
@@ -59,4 +58,3 @@ release:
   github:
     owner: sonatype-nexus-community
     name: ahab
-  


### PR DESCRIPTION
No longer building macos binary because macosx running in docker isn't really a thing.

It relates to the following issue #s:
* Fixes #36

cc @bhamail / @DarthHater
