### PR TITLE
Deprecate --os

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,18 +147,20 @@ Examples:
         yum list installed | ./ahab chase
         apk info -vv | sort | ./ahab chase
 
-
 Flags:
-  -v, -- count          Set log level, higher is more verbose
-      --clean-cache     Flag to clean the database cache for OSS Index
-  -h, --help            help for chase
-      --loud            Specify if you want non vulnerable packages included in your output
-      --no-color        Specify if you want no color in your results
-      --os string       Specify a value for the operating system type you want to scan (alpine, debian, fedora). Useful if autodetection fails and/or you want to explicitly set it.
-      --output string   Specify the output type you want (json, text, csv) (default "text")
-      --quiet           Quiet removes the header from being printed
-      --token string    Specify your OSS Index API Token
-      --user string     Specify your OSS Index Username
+  -v, -- count                              Set log level, higher is more verbose
+      --clean-cache                         Flag to clean the database cache for OSS Index
+  -e, --exclude-vulnerability CveListFlag   Comma separated list of CVEs to exclude (default [])
+  -x, --exclude-vulnerability-file string   Path to a file containing newline separated CVEs to be excluded (default "./.ahab-ignore")
+  -h, --help                                help for chase
+      --loud                                Specify if you want non vulnerable packages included in your output
+      --no-color                            Specify if you want no color in your results
+      --os string                           Specify a value for the operating system type you want to scan (alpine, debian, fedora). Useful if autodetection fails and/or you want to explicitly set it. (DEPRECATED: use package-manager)
+      --output string                       Specify the output type you want (json, text, csv) (default "text")
+      --package-manager string              Specify package manager type you want to scan (apk, dnf, dpkg or yum). Useful if autodetection fails and/or you want to explicitly set it.
+      --quiet                               Quiet removes the header from being printed
+      --token string                        Specify your OSS Index API Token
+      --user string                         Specify your OSS Index Username
 ```
 
 #### Exclude vulnerabilities
@@ -226,18 +228,19 @@ Examples:
 
 
 Flags:
-  -v, -- count                   Set log level, higher is more verbose
-      --application string       Specify public application ID for request (required)
-  -h, --help                     help for iq
-      --host string              Specify Nexus IQ Server URL (default "http://localhost:8070")
-      --max-retries int          Specify maximum number of tries to poll Nexus IQ Server (default 300)
-      --os string                Specify a value for the operating system type you want to scan (alpine, debian, fedora). Useful if autodetection fails and/or you want to explicitly set it.
-      --oss-index-token string   Specify your OSS Index API Token
-      --oss-index-user string    Specify your OSS Index Username
-      --quiet                    Quiet removes the header from being printed
-      --stage string             Specify stage for application (default "develop")
-      --token string             Specify Nexus IQ Token/Password for request (default "admin123")
-      --user string              Specify Nexus IQ Username for request (default "admin")
+  -v, -- count                              Set log level, higher is more verbose
+      --clean-cache                         Flag to clean the database cache for OSS Index
+  -e, --exclude-vulnerability CveListFlag   Comma separated list of CVEs to exclude (default [])
+  -x, --exclude-vulnerability-file string   Path to a file containing newline separated CVEs to be excluded (default "./.ahab-ignore")
+  -h, --help                                help for chase
+      --loud                                Specify if you want non vulnerable packages included in your output
+      --no-color                            Specify if you want no color in your results
+      --os string                           Specify a value for the operating system type you want to scan (alpine, debian, fedora). Useful if autodetection fails and/or you want to explicitly set it. (DEPRECATED: use package-manager)
+      --output string                       Specify the output type you want (json, text, csv) (default "text")
+      --package-manager string              Specify package manager type you want to scan (apk, dnf, dpkg or yum). Useful if autodetection fails and/or you want to explicitly set it.
+      --quiet                               Quiet removes the header from being printed
+      --token string                        Specify your OSS Index API Token
+      --user string                         Specify your OSS Index Username
 ```
 
 ## Why Ahab?

--- a/docker/apk/Dockerfile
+++ b/docker/apk/Dockerfile
@@ -9,4 +9,4 @@ COPY ahab .
 # Spit out these just for easier debugging
 RUN apk info -vv | sort
 
-RUN apk info -vv | sort | ./ahab chase --os alpine
+RUN apk info -vv | sort | ./ahab chase --package-manager apk

--- a/docker/dnf/Dockerfile
+++ b/docker/dnf/Dockerfile
@@ -9,5 +9,5 @@ COPY ahab .
 # Spit out these just for easier debugging
 RUN dnf list installed
 
-RUN dnf list installed | ./ahab chase --os fedora
+RUN dnf list installed | ./ahab chase --package-manager dnf
 

--- a/docker/dpkg-query/Dockerfile
+++ b/docker/dpkg-query/Dockerfile
@@ -9,5 +9,5 @@ COPY ahab .
 # Spit out these just for easier debugging
 RUN dpkg-query --show --showformat='${Package} ${Version}\n'
 
-RUN dpkg-query --show --showformat='${Package} ${Version}\n' | ./ahab chase --os debian
+RUN dpkg-query --show --showformat='${Package} ${Version}\n' | ./ahab chase --package-manager dpkg
 

--- a/docker/yum/Dockerfile
+++ b/docker/yum/Dockerfile
@@ -9,5 +9,5 @@ COPY ahab .
 # Spit out these just for easier debugging
 RUN yum list installed
 
-RUN yum list installed | ./ahab chase --os fedora
+RUN yum list installed | ./ahab chase --package-manager yum
 

--- a/packages/apk.go
+++ b/packages/apk.go
@@ -26,9 +26,9 @@ type Apk struct {
 	ProjectList parse.ProjectList
 }
 
-func (a Apk) ExtractPurlsFromProjectList(operating string) (purls []string) {
+func (a Apk) ExtractPurlsFromProjectList() (purls []string) {
 	for _, s := range a.ProjectList.Projects {
-		var purl = fmt.Sprintf("pkg:alpine/%s@%s", s.Name, s.Version)
+		var purl = fmt.Sprintf("pkg:apk/alpine/%s@%s", s.Name, s.Version)
 		purls = append(purls, purl)
 	}
 	return

--- a/packages/apt.go
+++ b/packages/apt.go
@@ -26,9 +26,9 @@ type Apt struct {
 	ProjectList parse.ProjectList
 }
 
-func (a Apt) ExtractPurlsFromProjectList(operating string) (purls []string) {
+func (a Apt) ExtractPurlsFromProjectList() (purls []string) {
 	for _, s := range a.ProjectList.Projects {
-		var purl = fmt.Sprintf("pkg:deb/%s/%s@%s", operating, s.Name, s.Version)
+		var purl = fmt.Sprintf("pkg:deb/debian/%s@%s", s.Name, s.Version)
 		purls = append(purls, purl)
 	}
 	return

--- a/packages/detector.go
+++ b/packages/detector.go
@@ -24,35 +24,32 @@ import (
 
 var execCommand = exec.Command
 
-const SupportedPackageManagers = "supported package managers are dpkg-query, apk yum or dnf, could not find any. Possible issues: 1.) dpkg-query, apk, yum or dnf is not installed. 2.) 'which' program is not installed to do auto detection"
+const SupportedPackageManagers = "Supported package managers are apk, dnf, dpkg or yum; could not find any. Possible issues: 1.) dpkg, apk, yum or dnf is not installed. 2.) 'which' program is not installed to do auto detection"
 
 func DetectPackageManager(logger *logrus.Logger) (string, error) {
-	var os string
+	var packageManager string
 
 	installed := determineIfPackageManagerInstalled("apk", logger)
 	if installed {
-		//Having this be OS is a little weird. It probably should have been just package manager based flag.
-		os = "alpine"
-		return os, nil
+		packageManager = "apk"
+		return packageManager, nil
 	}
 	installed = determineIfPackageManagerInstalled("dnf", logger)
 	if installed {
-		//Having this be OS is a little weird. It probably should have been just package manager based flag.
-		os = "fedora"
-		return os, nil
+		packageManager = "dnf"
+		return packageManager, nil
 	}
 	installed = determineIfPackageManagerInstalled("yum", logger)
 	if installed {
-		//Having this be OS is a little weird. It probably should have been just package manager based flag.
-		os = "older-fedora"
-		return os, nil
+		packageManager = "yum"
+		return packageManager, nil
 	}
 	installed = determineIfPackageManagerInstalled("dpkg-query", logger)
 	if installed {
-		os = "debian"
-		return os, nil
+		packageManager = "dpkg"
+		return packageManager, nil
 	} else {
-		return os, errors.New(SupportedPackageManagers)
+		return packageManager, errors.New(SupportedPackageManagers)
 	}
 }
 

--- a/packages/detector_test.go
+++ b/packages/detector_test.go
@@ -94,10 +94,10 @@ func TestDetectPackageManager(t *testing.T) {
 		expectedResult                  string
 		expectedErr                     error
 	}{
-		"apk":            {expectedInstalledPackageManager: "apkinstalled", expectedResult: "alpine", expectedErr: nil},
-		"yum":            {expectedInstalledPackageManager: "yuminstalled", expectedResult: "older-fedora", expectedErr: nil},
-		"dnf":            {expectedInstalledPackageManager: "dnfinstalled", expectedResult: "fedora", expectedErr: nil},
-		"dpkg-query":     {expectedInstalledPackageManager: "dpkgqueryinstalled", expectedResult: "debian", expectedErr: nil},
+		"apk":            {expectedInstalledPackageManager: "apkinstalled", expectedResult: "apk", expectedErr: nil},
+		"yum":            {expectedInstalledPackageManager: "yuminstalled", expectedResult: "yum", expectedErr: nil},
+		"dnf":            {expectedInstalledPackageManager: "dnfinstalled", expectedResult: "dnf", expectedErr: nil},
+		"dpkg-query":     {expectedInstalledPackageManager: "dpkgqueryinstalled", expectedResult: "dpkg", expectedErr: nil},
 		"none installed": {expectedInstalledPackageManager: "notinstalled", expectedResult: "", expectedErr: errors.New(SupportedPackageManagers)},
 	}
 

--- a/packages/package.go
+++ b/packages/package.go
@@ -17,5 +17,5 @@
 package packages
 
 type IPackage interface {
-	ExtractPurlsFromProjectList(string) []string
+	ExtractPurlsFromProjectList() []string
 }

--- a/packages/yum.go
+++ b/packages/yum.go
@@ -26,9 +26,9 @@ type Yum struct {
 	ProjectList parse.ProjectList
 }
 
-func (y Yum) ExtractPurlsFromProjectList(operating string) (purls []string) {
+func (y Yum) ExtractPurlsFromProjectList() (purls []string) {
 	for _, s := range y.ProjectList.Projects {
-		var purl = fmt.Sprintf("pkg:rpm/%s@%s", s.Name, s.Version)
+		var purl = fmt.Sprintf("pkg:rpm/fedora/%s@%s", s.Name, s.Version)
 		purls = append(purls, purl)
 	}
 	return


### PR DESCRIPTION
Deprecate --os in favor of --package-manager. Minor cleanup along the way.

This pull request makes the following changes:
* Deprecate --os (shouldn't break builds thanks to auto detection)
* Add --package-manager
* Minor updates to purl format for consistency across formats
* Minor tweak to flag setup in chase.go inspired by iq.go
* Update tests to use --package-manager

(If there are changes to user behavior in general, please make sure to
update the docs, as well)

It relates to the following issue #s:
* Addresses #29 

cc @bhamail / @DarthHater / @zendern 
